### PR TITLE
go-cross: host contamination fix

### DIFF
--- a/recipes-devtools/go/go-cross_1.4.bb
+++ b/recipes-devtools/go/go-cross_1.4.bb
@@ -37,7 +37,7 @@ do_compile() {
   export GO_CCFLAGS="${HOST_CFLAGS}"
   export GO_LDFLAGS="${HOST_LDFLAGS}"
 
-  cd src && sh -x ./make.bash
+  cd src && bash -x ./make.bash
 
   ## The result is `go env` giving this:
   # GOARCH="amd64"


### PR DESCRIPTION
On some platforms, sh != bash, explicitly invoke bash.

Signed-off-by: Amy Fong amy.fong.3142@gmail.com
