### PR TITLE
Fix Yocto go compilation issue

### DIFF
--- a/recipes-devtools/go/go-cross_1.4.bb
+++ b/recipes-devtools/go/go-cross_1.4.bb
@@ -32,8 +32,8 @@ do_compile() {
   ## TODO: consider setting GO_EXTLINK_ENABLED
 
   export CC="${BUILD_CC}"
-  export CC_FOR_TARGET="${CC}"
-  export CXX_FOR_TARGET="${CXX}"
+  export CC_FOR_TARGET="${TARGET_SYS}-gcc --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH}"
+  export CXX_FOR_TARGET="${TARGET_SYS}-g++ --sysroot=${STAGING_DIR_TARGET} ${TARGET_CC_ARCH}"
   export GO_CCFLAGS="${HOST_CFLAGS}"
   export GO_LDFLAGS="${HOST_LDFLAGS}"
 


### PR DESCRIPTION
Setting CC_FOR_TARGET to ${CC} looks to not work as by default it uses gcc. If this is the case compilation fails with "gcc: unrecognized command line option ‘-marm’" error. Changing above to  ${TARGET_SYS}-gcc fixes the compilation issue.
