### PR TITLE
go-cross: don't use host /var/tmp for temporary build artifacts

### DIFF
--- a/recipes-devtools/go/go-cross_1.4.bb
+++ b/recipes-devtools/go/go-cross_1.4.bb
@@ -37,6 +37,9 @@ do_compile() {
   export GO_CCFLAGS="${HOST_CFLAGS}"
   export GO_LDFLAGS="${HOST_LDFLAGS}"
 
+  export TMPDIR=${WORKDIR}/build-tmp
+  mkdir ${WORKDIR}/build-tmp
+
   cd src && sh -x ./make.bash
 
   ## The result is `go env` giving this:


### PR DESCRIPTION
The default behavior for go-cross build is to use the path specified
in TMPDIR for some temporary build artifacts and if no TMPDIR is set
in the environment to fallback to use /var/tmp. This causes a build
failure on hosts that do not have a /var/tmp or that have restrictive
permissions on /var/tmp. The failure is seen as:

```
go tool dist: mkdtemp(/var/tmp/go-cbuild-yhmNbi): No such file or directory
```

By setting TMPDIR and ensuring we create this
directory we can avoid the associated issue with using the default.

Signed-off-by: Mark Asselstine mark.asselstine@windriver.com
